### PR TITLE
Updated to 1.14.10

### DIFF
--- a/gopass.nuspec
+++ b/gopass.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.14.8</version>
+    <version>1.14.10</version>
     <packageSourceUrl>https://github.com/lyze237/GopassChoco</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>lyze</owners>
@@ -50,7 +50,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <tags>gopass password manager</tags>
     <summary>The slightly more awesome standard unix password manager for teams</summary>
     <description>gopass is a rewrite of the pass password manager in Go with the aim of making it cross-platform and adding additional features. Our target audience are professional developers and sysadmins (and especially teams of those) who are well versed with a command line interface. One explicit goal for this project is to make it more approachable to non-technical users. We go by the UNIX philosophy and try to do one thing and do it well, providing a stellar user experience and a sane, simple interface.</description>
-    <releaseNotes>https://github.com/gopasspw/gopass/releases/tag/v1.14.8</releaseNotes>
+    <releaseNotes>https://github.com/gopasspw/gopass/releases/tag/v1.14.10</releaseNotes>
     <!-- =============================== -->      
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $name          = 'gopass'
 $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64         = 'https://github.com/gopasspw/gopass/releases/download/v1.14.8/gopass-1.14.8-windows-amd64.zip' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
-$checksum64    = '4a53b2036ea55befa051bb00839b9fa5'
+$url64         = 'https://github.com/gopasspw/gopass/releases/download/v1.14.10/gopass-1.14.10-windows-amd64.zip' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
+$checksum64    = 'af21923cd49dc2d1bf933949c0ad88ff'
 
 Install-ChocolateyZipPackage -PackageName $name -UnzipLocation $toolsDir -Url64bit $url64 -Checksum64 $checksum64


### PR DESCRIPTION
Upgrade gopass to 1.14.10 to fix the "unused gpg key" removal in windows

closes #2 